### PR TITLE
Implementar o Swagger Framework para a documentação e testes dos serviços da API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ As seguintes ferramentas foram usadas na construção do projeto:
 - [Lombok](https://projectlombok.org/)
 - [Spring Reactive Web](https://docs.spring.io/spring-boot/docs/2.7.4/reference/htmlsingle/#web.reactive)
 - [Reactive feign](https://github.com/PlaytikaOSS/feign-reactive)
+- [Springdoc-openapi](https://springdoc.org/)
 
 ## 👨‍💻Autor
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,16 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.6.11</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-webflux-ui</artifactId>
+			<version>1.6.11</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Adicionando swagger na aplicação.
Acessar o link http://localhost:8080/swagger-ui.html para visualizar.

- https://github.com/aguiardafa/webflux-reactive-feign-vs-webclient/issues/1